### PR TITLE
Add VGG16 config support

### DIFF
--- a/recognition/arcface_torch/configs/base.py
+++ b/recognition/arcface_torch/configs/base.py
@@ -49,6 +49,9 @@ config.seed = 2048
 # dataload numworkers
 config.num_workers = 2
 
+# input image resolution
+config.image_size = 112
+
 # WandB Logger
 config.wandb_key = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 config.suffix_run_name = None

--- a/recognition/arcface_torch/configs/ms1mv3_arcface_VGG16.py
+++ b/recognition/arcface_torch/configs/ms1mv3_arcface_VGG16.py
@@ -34,6 +34,8 @@ config.dali = False
 # dataload numworkers
 config.num_workers = 12
 
+config.image_size = 224
+
 config.rec = "./train/ms1m-retinaface-t1"
 config.num_classes = 93431
 config.num_image = 5179510

--- a/recognition/arcface_torch/train_v2.py
+++ b/recognition/arcface_torch/train_v2.py
@@ -89,7 +89,8 @@ def main(args):
         cfg.dali,
         cfg.dali_aug,
         cfg.seed,
-        cfg.num_workers
+        cfg.num_workers,
+        cfg.image_size
     )
 
     backbone = get_model(
@@ -159,8 +160,10 @@ def main(args):
         logging.info(": " + key + " " * num_space + str(value))
 
     callback_verification = CallBackVerification(
-        val_targets=cfg.val_targets, rec_prefix=cfg.rec, 
-        summary_writer=summary_writer, wandb_logger = wandb_logger
+        val_targets=cfg.val_targets, rec_prefix=cfg.rec,
+        summary_writer=summary_writer,
+        image_size=(cfg.image_size, cfg.image_size),
+        wandb_logger = wandb_logger
     )
     callback_logging = CallBackLogging(
         frequent=cfg.frequent,

--- a/recognition/arcface_torch/utils/utils_callbacks.py
+++ b/recognition/arcface_torch/utils/utils_callbacks.py
@@ -13,7 +13,7 @@ from torch import distributed
 
 class CallBackVerification(object):
     
-    def __init__(self, val_targets, rec_prefix, summary_writer=None, image_size=(224, 224), wandb_logger=None): #mudei aqui!!!
+    def __init__(self, val_targets, rec_prefix, summary_writer=None, image_size=(112, 112), wandb_logger=None):
         self.rank: int = distributed.get_rank()
         self.highest_acc: float = 0.0
         self.highest_acc_list: List[float] = [0.0] * len(val_targets)


### PR DESCRIPTION
## Summary
- generalize dataloader image size
- update ArcFace config to use 224px images for VGG16
- pass image size through training and evaluation callbacks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_684f537425a08328a912c50cee3ee961